### PR TITLE
Update ocropus-rtrain

### DIFF
--- a/ocropus-rtrain
+++ b/ocropus-rtrain
@@ -27,7 +27,7 @@ parser.add_argument("--dewarp",action="store_true",
                     help="only perform line estimation and output .dew.png file")
 
 # character set
-parser.add_argument("-c","--codec",default=None,
+parser.add_argument("-c","--codec",action="store_true",
                     help="construct a codec from the input text")
 
 # learning
@@ -119,7 +119,7 @@ if args.codec is not None:
     print "# building codec"
     codec = lstm.Codec()
     charset = set()
-    for fname in ocrolib.glob_all(args.codec):
+    for fname in ocrolib.glob_all(args.files):
         assert os.path.exists(fname)
         base,_ = ocrolib.allsplitext(fname)
         transcript = ocrolib.read_text(base+".gt.txt")


### PR DESCRIPTION
Currently there is a little bug in making a new codec. The argument -c needs a list of input text files (nargs='+/*' missing). Or else, -c could be used to store an action and then use args.files to build a new codec. There are a lot of confusion among new users on how to train ocropus for new languages, and I found this bug. I've tested this with some languages and found the current modification working.
