### PR TITLE
Allow ocropus-nlbin to run in headless environment

### DIFF
--- a/ocropus-nlbin
+++ b/ocropus-nlbin
@@ -184,7 +184,6 @@ def process1(job):
     print fname,"lo-hi (%.2f %.2f) angle %4.1f"%(lo,hi,angle),comment
     if args.parallel<2: print "writing"
     if args.debug>0 or args.show: clf(); gray();imshow(bin); ginput(1,max(0.1,args.debug))
-    gray()
     if args.output:
         if args.rawcopy: ocrolib.write_image_gray(args.output+"/%04d.raw.png"%i,raw)
         ocrolib.write_image_binary(args.output+"/%04d.bin.png"%i,bin)


### PR DESCRIPTION
This call to `gray()` tries to open a display window, which throws an exception if `ocropus-nlbin` is running in a GUI-less environment (e.g. a Docker container). As far as I can tell this call is not needed since it will get called in the previous line if `args.show` is true.
