### PR TITLE
An option to output scores and alternate chars.

### DIFF
--- a/ocrolib/lstm.py
+++ b/ocrolib/lstm.py
@@ -728,6 +728,34 @@ def translate_back(outputs,threshold=0.7,pos=0):
     if pos: return maxima
     return [c for (r,c) in maxima]
 
+def translate_back_with_alternates(orig_outputs, threshold=0.7, alt_threshold=0.1):
+    """Like translate_back, but returns a list of possibilities at each pos.
+
+    Output is a list of [(letter1, score1), (letter2, score2), ...].
+    """
+    outputs = orig_outputs.copy()
+    labels, n = measurements.label(outputs[:,0] < threshold)
+    mask = tile(labels.reshape(-1, 1), (1, outputs.shape[1]))
+
+    outputs[:,0] = 0
+    outputs[mask == 0] = 0
+    out_scores = []
+    while outputs.max() > alt_threshold:
+        maxima = measurements.maximum_position(outputs, mask, arange(1,amax(mask)+1))
+        scores = [(c, outputs[r,c]) for r, c in maxima]
+        out_scores.append(scores)
+
+        # Clear the max cols to expose the next-highest values.
+        for i, (r, c) in enumerate(maxima):
+            col_mask = np.zeros(outputs.shape)
+            col_mask[:,c] = 1
+            outputs[mask * col_mask == i+1] = 0
+
+    scores = zip(*out_scores)
+    return [[(c, score) for c, score in char if score > alt_threshold]
+            for char in scores]
+
+
 def log_mul(x,y):
     "Perform multiplication in the log domain (i.e., addition)."
     return x+y

--- a/ocropus-rpred
+++ b/ocropus-rpred
@@ -3,6 +3,7 @@
 import traceback
 import codecs
 from pylab import *
+import json
 import os.path
 import ocrolib
 import argparse
@@ -56,6 +57,8 @@ parser.add_argument("-q","--quiet",action="store_true",
                     help="turn off most output")
 parser.add_argument("-Q","--parallel",type=int,default=1,
                     help="number of parallel processes to use (%(default)s)")
+parser.add_argument('--alternates', action='store_true',
+                    help='Output JSON file with scores and alternate characters.')
 
 # input files
 parser.add_argument("files",nargs="+",
@@ -171,6 +174,12 @@ def process1(arg):
                     c = network.l2s([c])
                     r = (r-args.pad)*scale
                     locs.write("%s\t%.1f\n"%(c,r))
+
+    if args.alternates:
+        alts = lstm.translate_back_with_alternates(network.outputs)
+        chars = [[(network.l2s([c]), score) for c, score in char if c > 0]
+                    for char in alts]
+        json.dump(chars, open(base + '.alts.json', 'w'), indent=2)
 
     if not args.nonormalize:
         pred = ocrolib.normalize_text(pred)


### PR DESCRIPTION
When requested, this data is written into a `.alts.json` file alongside the line image.

For example:

```
$ ./ocropus-rpred --alternates -n -m models/en-default.pyrnn.gz book/0001/010004.bin.png
$ cat book/0001/010004.alts.json
[
  [
    [
      "a",
      0.78196890563642629
    ],
    [
      "s",
      0.33257442535877763
    ]
  ],
  ...
]
```

Fixes #16 