### PR TITLE
Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,44 @@
+language: python
+python:
+# This is not actually used. Because it would take an overly long time
+# to build scipy we cannot use the virtual env of travis. Instead, we
+# use miniconda.
+  - "2.7"
+
+sudo: false
+
+install:
+  # Install miniconda
+  # -----------------
+  - if [[ "$TRAVIS_PYTHON_VERSION" == 2* ]]; then
+      wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+
+  # Create the basic testing environment
+  # ------------------------------------
+  - conda config --set always_yes yes --set changeps1 no --set show_channel_urls yes
+  - conda update conda
+  - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION
+  - source activate test-environment
+
+  # Customise the testing environment
+  # ---------------------------------
+  - conda install --file requirements.txt
+
+  # Conda debug
+  #-----------
+  - conda list
+
+  # Install ocropy
+  # --------------
+  - wget -O models/en-default.pyrnn.gz http://www.tmbdev.net/en-default.pyrnn.gz
+  - python setup.py install
+
+script:
+  - mkdir ../test_folder
+  - cd ../test_folder
+  - ../ocropy/run-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ python:
 
 sudo: false
 
+cache:
+  directories:
+    - $HOME/.cache/matplotlib
+
 install:
   # Install miniconda
   # -----------------

--- a/README.md
+++ b/README.md
@@ -40,10 +40,19 @@ Alternatively, dependencies can be installed into a [Python Virtual Environment]
     $ wget -nd http://www.tmbdev.net/en-default.pyrnn.gz
     $ mv en-default.pyrnn.gz models/
 
+An additional method using [Conda](http://conda.pydata.org/) is also possible:
+
+    $ conda create -n ocropus_env python=2.7
+    $ source activate ocropus_env
+    $ conda install --file requirements.txt
+    $ wget -nd http://www.tmbdev.net/en-default.pyrnn.gz
+    $ mv en-default.pyrnn.gz models/
+    $ python setup.py install
+
 To test the recognizer, run:
 
     $ ./run-test
-    
+
 Running
 -------
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ trace by default since it seems to confuse too many users).
 Installing
 ----------
 
+[![Build Status](https://travis-ci.org/tmbdev/ocropy.svg)](https://travis-ci.org/tmbdev/ocropy)
 [![Join the chat at https://gitter.im/tmbdev/ocropy](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/tmbdev/ocropy?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 To install OCRopus dependencies system-wide:

--- a/run-coverage
+++ b/run-coverage
@@ -1,17 +1,19 @@
 #!/bin/bash -e
 
+BASE=$(dirname $0)
+
 rm -rf .coverage
 rm -rf .coverage.*
 rm -rf temp 
-python -m coverage run -p ocropus-nlbin tests/testpage.png -o temp
+python -m coverage run -p ocropus-nlbin $BASE/tests/testpage.png -o temp
 python -m coverage run -p ocropus-gpageseg 'temp/????.bin.png'
 python -m coverage run -p ocropus-rpred -n 'temp/????/??????.bin.png'
 python -m coverage run -p ocropus-hocr 'temp/????.bin.png' -o temp.html
 python -m coverage run -p ocropus-visualize-results temp
 python -m coverage run -p ocropus-gtedit html temp/????/??????.bin.png -o temp-correction.html
-python -m coverage run -p ocropus-rpred tests/0079-01000d.png
-python -m coverage run -p ocropus-errs tests/0079-01000d.gt.txt
-python -m coverage run -p ocropus-econf tests/0079-01000d.gt.txt
+python -m coverage run -p ocropus-rpred $BASE/tests/0079-01000d.png
+python -m coverage run -p ocropus-errs $BASE/tests/0079-01000d.gt.txt
+python -m coverage run -p ocropus-econf $BASE/tests/0079-01000d.gt.txt
 python -m coverage merge
 rm -rf htmlcov
 python -m coverage html

--- a/run-rtrain
+++ b/run-rtrain
@@ -1,4 +1,6 @@
 #!/bin/bash -ex
 
-tar -zxf tests/uw3-500.tgz
+BASE=$(dirname $0)
+
+tar -zxf $BASE/tests/uw3-500.tgz
 ocropus-rtrain 'book/*/*.bin.png' -d 5 -o uw3-500-model

--- a/run-test
+++ b/run-test
@@ -1,7 +1,9 @@
 #!/bin/bash -e
 
+BASE=$(dirname $0)
+
 rm -rf temp 
-ocropus-nlbin tests/testpage.png -o temp
+ocropus-nlbin $BASE/tests/testpage.png -o temp
 ocropus-gpageseg 'temp/????.bin.png'
 ocropus-rpred -n 'temp/????/??????.bin.png'
 ocropus-hocr 'temp/????.bin.png' -o temp.html


### PR DESCRIPTION
A very simple setup for testing via Travis. It uses Miniconda to install dependencies and then runs the test script. I originally tried a straight install, but compiling SciPy took so long, it [ran out of build time](https://travis-ci.org/QuLogic/ocropy/builds/62312903). The conda install is much much quicker.

You will of course have to enable Travis for your repo before this has a real effect. And it doesn't really check whether the result correct, only that something is produced, but that's how the existing test script is. One could also do coverage testing using the other script and coveralls.io, but that's something for a another PR.
