### PR TITLE
Clean name for new output directory

### DIFF
--- a/ocropus-linegen
+++ b/ocropus-linegen
@@ -193,7 +193,8 @@ for pageno,font in enumerate(fonts):
     if args.numdir:
         pagedir = "%s/%04d"%(base,pageno+1)
     else:
-        fbase = re.sub(r'[.][^/]*$','',font)
+        fbase = re.sub(r'^[./]*','',font)
+        fbase = re.sub(r'[.][^/]*$','',fbase)
         fbase = re.sub(r'[/]','_',fbase)
         pagedir = "%s/%s"%(base,fbase)
     os.mkdir(pagedir)


### PR DESCRIPTION
The font may be saved below in the file tree and therefore the new direcotry will start with `../` which is by default a invisible file. E.g.
```
ocropus-linegen -t ../text-generation/text.txt -f ../text-generation/font.ttf -m 5 -o ../text-generation/linegen
```
will create a directory `/text-generation/linegen/.._font/` which is mostly invisible and the naming in this case is really ugly.

This should be an easy and safe fix.