### PR TITLE
added uint64 to integer types

### DIFF
--- a/ocrolib/toplevel.py
+++ b/ocrolib/toplevel.py
@@ -289,7 +289,7 @@ except: pass
 def AFLOAT(a):
     return a.dtype in float_dtypes
 
-int_dtypes = [numpy.dtype('uint8'),numpy.dtype('int32'),numpy.dtype('int64'),numpy.dtype('uint32')]
+int_dtypes = [numpy.dtype('uint8'),numpy.dtype('int32'),numpy.dtype('int64'),numpy.dtype('uint32'),numpy.dtype('uint64')]
 
 @makeargcheck("array must contain integer values")
 def AINT(a):


### PR DESCRIPTION
Fixed this issue:
`<ndarray-7feb15be2060 (380, 550) uint64 [0,1105]> of type <type 'numpy.ndarray'>: array must contain integer values`