### PR TITLE
Added better print methods for distinguishing between info and error …

### DIFF
--- a/ocrolib/common.py
+++ b/ocrolib/common.py
@@ -194,9 +194,9 @@ def pil2array(im,alpha=0):
 def array2pil(a):
     if a.dtype==dtype("B"):
         if a.ndim==2:
-            return PIL.Image.fromstring("L",(a.shape[1],a.shape[0]),a.tostring())
+            return PIL.Image.frombytes("L",(a.shape[1],a.shape[0]),a.tostring())
         elif a.ndim==3:
-            return PIL.Image.fromstring("RGB",(a.shape[1],a.shape[0]),a.tostring())
+            return PIL.Image.frombytes("RGB",(a.shape[1],a.shape[0]),a.tostring())
         else:
             raise OcropusException("bad image rank")
     elif a.dtype==dtype('float32'):
@@ -1067,4 +1067,3 @@ class MovingStats:
     def mean(self):
         if len(self.data)==0: return nan
         return mean(self.data)
-

--- a/ocropus-gpageseg
+++ b/ocropus-gpageseg
@@ -11,6 +11,7 @@
 # - pick up stragglers
 # ? laplacian as well
 
+from __future__ import print_function
 from pylab import *
 import argparse,glob,os,os.path
 import traceback
@@ -102,13 +103,21 @@ def check_page(image):
     if ncomps>slots: return "too many connnected components for a page image (%d > %d)"%(ncomps,slots)
     return None
 
+
+def print_info(*objs):
+    print("INFO: ", *objs, file=sys.stdout)
+
+def print_error(*objs):
+    print("ERROR: ", *objs, file=sys.stderr)
+
+
 if len(args.files)<1:
     parser.print_help()
     sys.exit(0)
 
-print 
-print "#"*10,(" ".join(sys.argv))[:60]
-print 
+print_info("")
+print_info("#"*10,(" ".join(sys.argv))[:60])
+print_info("")
 
 if args.parallel>1:
     args.quiet = 1
@@ -123,7 +132,7 @@ def DSAVE(title,image):
         assert len(image)==3
         image = transpose(array(image),[1,2,0])
     fname = "_"+title+".png"
-    print "debug",fname
+    print_info("debug " + fname)
     imsave(fname,image)
 
 
@@ -296,20 +305,20 @@ def compute_segmentation(binary,scale):
     binary = remove_hlines(binary,scale)
 
     # do the column finding
-    if not args.quiet: print "computing column separators"
+    if not args.quiet: print_info("computing column separators")
     colseps,binary = compute_colseps(binary,scale)
 
     # now compute the text line seeds
-    if not args.quiet: print "computing lines"
+    if not args.quiet: print_info("computing lines")
     bottom,top,boxmap = compute_gradmaps(binary,scale)
     seeds = compute_line_seeds(binary,bottom,top,colseps,scale)
     DSAVE("seeds",[bottom,top,boxmap])
 
     # spread the text line seeds to all the remaining
     # components
-    if not args.quiet: print "propagating labels"
+    if not args.quiet: print_info("propagating labels")
     llabels = morph.propagate_labels(boxmap,seeds,conflict=0)
-    if not args.quiet: print "spreading labels"
+    if not args.quiet: print_info("spreading labels")
     spread = morph.spread_labels(seeds,maxdist=scale)
     llabels = where(llabels>0,llabels,spread*binary)
     segmentation = llabels*binary
@@ -334,15 +343,15 @@ def process1(job):
             binary = ocrolib.read_image_binary(fname)
         except IOError:
             if ocrolib.trace: traceback.print_exc()
-            print "cannot open either",base+".bin.png","or",fname
+            print_error("cannot open either " + base+".bin.png" + " or " + fname)
             return
 
     checktype(binary,ABINARY2)
- 
+
     if not args.nocheck:
         check = check_page(amax(binary)-binary)
         if check is not None:
-            print fname,"SKIPPED",check,"(use -n to disable this check)"
+            print_error(fname + " SKIPPED " + check + " (use -n to disable this check)")
             return
 
     if args.gray:
@@ -356,26 +365,26 @@ def process1(job):
         scale = psegutils.estimate_scale(binary)
     else:
         scale = args.scale
-    print "scale",scale
+    print_info("scale " + str(scale))
     if isnan(scale) or scale>1000.0:
-        sys.stderr.write("%s: bad scale (%g); skipping\n"%(fname,scale))
+        print_error("%s: bad scale (%g); skipping\n"%(fname,str(scale)))
         return
     if scale<args.minscale:
-        sys.stderr.write("%s: scale (%g) less than --minscale; skipping\n"%(fname,scale))
+        print_error("%s: scale (%g) less than --minscale; skipping\n"%(fname,str(scale)))
         return
 
     # find columns and text lines
 
-    if not args.quiet: print "computing segmentation"
+    if not args.quiet: print_info("computing segmentation")
     segmentation = compute_segmentation(binary,scale)
-    if amax(segmentation)>args.maxlines: 
-        print fname,": too many lines",amax(segmentation)
-        return 
-    if not args.quiet: print "number of lines",amax(segmentation)
+    if amax(segmentation)>args.maxlines:
+        print_error(fname + ": too many lines" + str(amax(segmentation)))
+        return
+    if not args.quiet: print_info("number of lines"+ str(amax(segmentation)))
 
     # compute the reading order
 
-    if not args.quiet: print "finding reading order"
+    if not args.quiet: print_info("finding reading order")
     lines = psegutils.compute_lines(segmentation,scale)
     order = psegutils.reading_order([l.bounds for l in lines])
     lsort = psegutils.topsort(order)
@@ -389,7 +398,7 @@ def process1(job):
 
     # finally, output everything
 
-    if not args.quiet: print "writing lines"
+    if not args.quiet: print_info("writing lines")
     if not os.path.exists(outputdir):
         os.mkdir(outputdir)
     lines = [lines[i] for i in lsort]
@@ -401,7 +410,7 @@ def process1(job):
         if args.gray:
             grayline = psegutils.extract_masked(gray,l,pad=args.pad,expand=args.expand)
             ocrolib.write_image_gray("%s/01%04x.nrm.png"%(outputdir,i+1),grayline)
-    print "%6d"%i,fname,"%4.1f"%scale,len(lines)
+    print_info("%6d "%i + fname + " %4.1f "%  + scale + " " + str(len(lines)))
 
 if len(args.files)==1 and os.path.isdir(args.files[0]):
     files = glob.glob(args.files[0]+"/????.png")
@@ -416,14 +425,14 @@ def safe_process1(job):
         if e.trace:
             traceback.print_exc()
         else:
-            print fname,":",e
+            print_info(fname+":"+e)
     except Exception as e:
         traceback.print_exc()
 
 if args.parallel<2:
     count = 0
     for i,f in enumerate(files):
-        if args.parallel==0: print f
+        if args.parallel==0: print_info(f)
         count += 1
         safe_process1((f,i+1))
 else:

--- a/ocropus-nlbin
+++ b/ocropus-nlbin
@@ -8,6 +8,7 @@ from scipy.ndimage import filters,interpolation,morphology,measurements
 from scipy import stats
 import multiprocessing
 import ocrolib
+import warnings
 
 
 
@@ -134,6 +135,7 @@ def process1(job):
     else:
         # if not, we need to flatten it by estimating the local whitelevel
         if args.parallel<2: print_info("flattening")
+        warnings.filterwarnings("ignore", category=UserWarning)
         m = interpolation.zoom(image,args.zoom)
         m = filters.percentile_filter(m,args.perc,size=(args.range,2))
         m = filters.percentile_filter(m,args.perc,size=(2,args.range))
@@ -141,6 +143,7 @@ def process1(job):
         if args.debug>0: clf(); imshow(m,vmin=0,vmax=1); ginput(1,args.debug)
         w,h = minimum(array(image.shape),array(m.shape))
         flat = clip(image[:w,:h]-m[:w,:h]+1,0,1)
+        warnings.resetwarnings()
         if args.debug>0: clf(); imshow(flat,vmin=0,vmax=1); ginput(1,args.debug)
 
     # estimate skew angle and rotate
@@ -161,6 +164,7 @@ def process1(job):
 
     # estimate low and high thresholds
     if args.parallel<2: print_info("estimating thresholds")
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
     d0,d1 = flat.shape
     o0,o1 = int(args.bignore*d0),int(args.bignore*d1)
     est = flat[o0:d0-o0,o1:d1-o1]
@@ -178,7 +182,7 @@ def process1(job):
         est = est[v]
     lo = stats.scoreatpercentile(est.ravel(),args.lo)
     hi = stats.scoreatpercentile(est.ravel(),args.hi)
-
+    warnings.resetwarnings()
     # rescale the image to get the gray scale image
     if args.parallel<2: print_info("rescaling")
     flat -= lo

--- a/ocropus-nlbin
+++ b/ocropus-nlbin
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 from pylab import *
 from numpy.ctypeslib import ndpointer
 import argparse,os,os.path
@@ -45,6 +46,12 @@ if len(args.files)<1:
     sys.exit(0)
 
 
+def print_info(*objs):
+    print("INFO: ", *objs, file=sys.stdout)
+
+def print_error(*objs):
+    print("ERROR: ", *objs, file=sys.stderr)
+
 def check_page(image):
     if len(image.shape)==3: return "input image is color image %s"%(image.shape,)
     if mean(image)<median(image): return "image may be inverted"
@@ -76,7 +83,7 @@ def estimate_skew_angle(image,angles):
         ginput(1,args.debug)
     _,a = max(estimates)
     return a
-    
+
 def select_regions(binary,f,min=0,nbest=100000):
     labels,n = measurements.label(binary)
     objects = measurements.find_objects(labels)
@@ -98,22 +105,22 @@ def dshow(image,info):
 
 def process1(job):
     fname,i = job
-    print "#",fname
-    if args.parallel<2: print "===",fname,i
+    print_info("#" + fname)
+    if args.parallel<2: print_info("=== "+fname+ " " +str(i))
     comment = ""
     raw = ocrolib.read_image_gray(fname)
     dshow(raw,"input")
     # perform image normalization
     image = raw-amin(raw)
-    if amax(image)==amin(image): 
-        print "# image is empty",fname
+    if amax(image)==amin(image):
+        print_info("# image is empty" + fname)
         return
     image /= amax(image)
 
     if not args.nocheck:
         check = check_page(amax(image)-image)
         if check is not None:
-            print fname,"SKIPPED",check,"(use -n to disable this check)"
+            print_error(fname+"SKIPPED"+check+"(use -n to disable this check)")
             return
 
     # check whether the image is already effectively binarized
@@ -126,7 +133,7 @@ def process1(job):
         flat = image
     else:
         # if not, we need to flatten it by estimating the local whitelevel
-        if args.parallel<2: print "flattening"
+        if args.parallel<2: print_info("flattening")
         m = interpolation.zoom(image,args.zoom)
         m = filters.percentile_filter(m,args.perc,size=(args.range,2))
         m = filters.percentile_filter(m,args.perc,size=(2,args.range))
@@ -138,7 +145,7 @@ def process1(job):
 
     # estimate skew angle and rotate
     if args.maxskew>0:
-        if args.parallel<2: print "estimating skew angle"
+        if args.parallel<2: print_info("estimating skew angle")
         d0,d1 = flat.shape
         o0,o1 = int(args.bignore*d0),int(args.bignore*d1)
         flat = amax(flat)-flat
@@ -153,7 +160,7 @@ def process1(job):
         angle = 0
 
     # estimate low and high thresholds
-    if args.parallel<2: print "estimating thresholds"
+    if args.parallel<2: print_info("estimating thresholds")
     d0,d1 = flat.shape
     o0,o1 = int(args.bignore*d0),int(args.bignore*d1)
     est = flat[o0:d0-o0,o1:d1-o1]
@@ -173,7 +180,7 @@ def process1(job):
     hi = stats.scoreatpercentile(est.ravel(),args.hi)
 
     # rescale the image to get the gray scale image
-    if args.parallel<2: print "rescaling"
+    if args.parallel<2: print_info("rescaling")
     flat -= lo
     flat /= (hi-lo)
     flat = clip(flat,0,1)
@@ -181,8 +188,8 @@ def process1(job):
     bin = 1*(flat>args.threshold)
 
     # output the normalized grayscale and the thresholded images
-    print fname,"lo-hi (%.2f %.2f) angle %4.1f"%(lo,hi,angle),comment
-    if args.parallel<2: print "writing"
+    print_info(fname+" lo-hi (%.2f %.2f) angle %4.1f"%(lo,hi,angle) + comment)
+    if args.parallel<2: print_info("writing")
     if args.debug>0 or args.show: clf(); gray();imshow(bin); ginput(1,max(0.1,args.debug))
     if args.output:
         if args.rawcopy: ocrolib.write_image_gray(args.output+"/%04d.raw.png"%i,raw)
@@ -202,7 +209,7 @@ if args.output:
         os.mkdir(args.output)
 
 if args.parallel<2:
-    for i,f in enumerate(args.files): 
+    for i,f in enumerate(args.files):
         process1((f,i+1))
 else:
     pool = multiprocessing.Pool(processes=args.parallel)

--- a/ocropus-rpred
+++ b/ocropus-rpred
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+from __future__ import print_function
 import traceback
 import codecs
 from pylab import *
@@ -62,6 +62,12 @@ parser.add_argument("files",nargs="+",
                     help="input files; glob and @ expansion performed")
 args = parser.parse_args()
 
+def print_info(*objs):
+    print("INFO: ", *objs, file=sys.stdout)
+
+def print_error(*objs):
+    print("ERROR: ", *objs, file=sys.stderr)
+
 def check_line(image):
     if len(image.shape)==3: return "input image is color image %s"%(image.shape,)
     if mean(image)<median(image): return "image may be inverted"
@@ -84,13 +90,13 @@ if len(args.files)<1:
     parser.print_help()
     sys.exit(0)
 
-print 
-print "#"*10,(" ".join(sys.argv))[:60]
-print 
+print_info("")
+print_info("#"*10,(" ".join(sys.argv))[:60])
+print_info("")
 
 
 inputs = ocrolib.glob_all(args.files)
-if not args.quiet: print "#inputs",len(inputs)
+if not args.quiet: print_info("#inputs"+ str(len(inputs)))
 
 # disable parallelism when anything is being displayed
 
@@ -102,15 +108,15 @@ if args.show>=0 or args.save is not None:
 try:
   network = ocrolib.load_object(args.model,verbose=1)
   for x in network.walk(): x.postLoad()
-  for x in network.walk(): 
+  for x in network.walk():
       if isinstance(x,lstm.LSTM):
           x.allocate(5000)
 except ocrolib.FileNotFound:
-  print
-  print "Cannot find OCR model file:",args.model
-  print "Download a model and put it into:",ocrolib.default.modeldir
-  print "(Or override the location with OCROPUS_DATA.)"
-  print
+  print_error("")
+  print_error("Cannot find OCR model file:" + args.model)
+  print_error("Download a model and put it into:" + ocrolib.default.modeldir)
+  print_error("(Or override the location with OCROPUS_DATA.)")
+  print_error("")
   sys.exit(1)
 
 # get the line normalizer from the loaded network, or optionally
@@ -134,8 +140,8 @@ def process1(arg):
     if not args.nocheck:
         check = check_line(amax(line)-line)
         if check is not None:
-            print fname,"SKIPPED",check,"(use -n to disable this check)"
-            return (0,[],0,trial,fname)            
+            print_error(fname+" SKIPPED "+check+" (use -n to disable this check)")
+            return (0,[],0,trial,fname)
 
     if not args.nolineest:
         assert "dew.png" not in fname,"don't dewarp dewarped images"
@@ -192,12 +198,12 @@ def process1(arg):
             err = edist.xlevenshtein(pred0,gt0)
             conf = []
         if not args.quiet:
-            print "%3d %3d"%(err,len(gt)),fname,":",pred
+            print_info("%3d %3d"%(err,len(gt)) + " " + fname+":"+pred)
             sys.stdout.flush()
         return (err,conf,len(gt0),trial,fname)
 
     if not args.quiet:
-        print fname,":",pred
+        print_info(fname+":"+pred)
     ocrolib.write_text(base+".txt",pred)
 
     if args.show>0 or args.save is not None:
@@ -231,7 +237,7 @@ def process1(arg):
             draw()
             savename = args.save
             if "%" in savename: savename = savename%trial
-            print "saving",savename
+            print_info("saving "+savename)
             savefig(savename,bbox_inches=0)
         if trial==len(inputs)-1:
             ginput(1,99999999)
@@ -245,10 +251,10 @@ def safe_process1(arg):
         return process1(arg)
     except IOError as e:
         if ocrolib.trace: traceback.print_exc()
-        print fname,":",e
+        print_info(fname+":"+e)
     except ocrolib.OcropusException as e:
         if e.trace: traceback.print_exc()
-        print fname,":",e
+        print_info(fname+":"+e)
     except:
         traceback.print_exc()
         return None
@@ -280,8 +286,8 @@ if args.estrate:
         terr += err
         total += n
         confusions += conf
-    print "%.5f"%(terr*1.0/total),terr,total,args.model
+    print_info("%.5f"%(terr*1.0/total) + " " + terr+ " " + total + " " + args.model)
     if args.estconf>0:
-        print "top",args.estconf,"confusions (count pred gt), comparison:",args.compare
+        print_info("top " + args.estconf + " confusions (count pred gt), comparison: " + args.compare)
         for ((u,v),n) in Counter(confusions).most_common(args.estconf):
-            print "%6d %-4s %-4s"%(n,u,v)
+            print_info("%6d %-4s %-4s"%(n,u,v))


### PR DESCRIPTION
I changed printing to a new (future proof) method and changed the output a bit. 
My reasoning behind this is the following: 

I am currently writing a nodejs wrapper to build a RESTful API to use ocropy over the web. To be able to easily distinguish if an operation ran correct or not I need to check if ocropy wrote to stderr or not.

If you can agree with these changes, I could add the same printing to the other ocropy methods as well.