### PR TITLE
Add Portuguese specific characters to the default charset

### DIFF
--- a/ocrolib/chars.py
+++ b/ocrolib/chars.py
@@ -14,7 +14,7 @@ german = u"ÄäÖöÜüß"
 french = u"ÀàÂâÆæÇçÉéÈèÊêËëÎîÏïÔôŒœÙùÛûÜüŸÿ"
 turkish = u"ĞğŞşıſ"
 greek = u"ΑαΒβΓγΔδΕεΖζΗηΘθΙιΚκΛλΜμΝνΞξΟοΠπΡρΣσςΤτΥυΦφΧχΨψΩω"
-portuguese = "ªÁÃÌÍÒÓÕÚáãìíòóõú"
+portuguese = u"ªÁÃÌÍÒÓÕÚáãìíòóõú"
 
 default = ascii+xsymbols+german+french+portuguese
 

--- a/ocrolib/chars.py
+++ b/ocrolib/chars.py
@@ -14,8 +14,9 @@ german = u"ÄäÖöÜüß"
 french = u"ÀàÂâÆæÇçÉéÈèÊêËëÎîÏïÔôŒœÙùÛûÜüŸÿ"
 turkish = u"ĞğŞşıſ"
 greek = u"ΑαΒβΓγΔδΕεΖζΗηΘθΙιΚκΛλΜμΝνΞξΟοΠπΡρΣσςΤτΥυΦφΧχΨψΩω"
+portuguese = "ªÁÃÌÍÒÓÕÚáãìíòóõú"
 
-default = ascii+xsymbols+german+french
+default = ascii+xsymbols+german+french+portuguese
 
 european = default+turkish+greek
 


### PR DESCRIPTION
This PR aims to add some missing characters at ocrlib so it can able to properly manage Portuguese language. The new characters are:

```
ªÁÃÌÍÒÓÕÚáãìíòóõú
```

The list above was generated using this [article](http://www.inf.ufrgs.br/~irmmenezes/doku.php?id=res:acentuacao)[1] as a reference.

Then, the list was compared with `ocrolib.chars.default` to determine only the unique ones. The method was:

```
./run-rtrain
```

`[CTRL-C]` when you see:

```
# using default codec
# charset size # [...]
```

Copy/paste the default charset result ina file. Lets call it `charset_default.txt`. In another file, `charset_local.txt`, put the all the characters in [1]. Then compare the two files to extract only the unique ones with:

```
grep -F -x -v -f charset_default.txt charset_local.txt
```

This generated the list, one character per line. 

After that, the difficult to OCR characters were removed from the result:

```
±²³¹º¼½¾…‰™
```

The new lines were also removed so the new list of this PR gets done.

The result can be verified with the script bellow (save it as `listchar` then `chmod +x listchar`):

``` python
#!/usr/bin/env python

import ocrolib
from ocrolib import lineest
import ocrolib.lstm as lstm

charset = sorted(list(set(list(lstm.ascii_labels) + list(ocrolib.chars.default))))
charset = [""," ","~",]+[c for c in charset if c not in [" ","~"]]
print "# default charset size",len(charset),"\n",
if len(charset)<200:
    print "["+"".join(charset)+"]"
else:
    s = "".join(charset)
    print "["+s[:20],"...",s[-20:]+"]"
codec = lstm.Codec().init(charset)
```

Output **before** this PR:

```
./listchar
# default charset size 157
[ ~!"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}¡¢£§©«®°¶»¿ÀÂÄÆÇÈÉÊËÎÏÔÖÙÛÜßàâäæçèéêëîïôö÷ùûüÿŒœŸ†‡•‣‹›€∙▪▫◦]
```

Output **after** this PR:

```
./listchar
# default charset size 174
[ ~!"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}¡¢£§©ª«®°¶»¿ÀÁÂÃÄÆÇÈÉÊËÌÍÎÏÒÓÔÕÖÙÚÛÜßàáâãäæçèéêëìíîïòóôõö÷ùúûüÿŒœŸ†‡•‣‹›€∙▪▫◦]
```

[1] _Menezes, I. (2009) Todos os acentos da língua portuguesa Brasil_
