### PR TITLE
Changed tostring() to tobytes() because the former is deprecated

### DIFF
--- a/ocrolib/common.py
+++ b/ocrolib/common.py
@@ -177,15 +177,15 @@ import PIL
 
 def pil2array(im,alpha=0):
     if im.mode=="L":
-        a = numpy.fromstring(im.tostring(),'B')
+        a = numpy.fromstring(im.tobytes(),'B')
         a.shape = im.size[1],im.size[0]
         return a
     if im.mode=="RGB":
-        a = numpy.fromstring(im.tostring(),'B')
+        a = numpy.fromstring(im.tobytes(),'B')
         a.shape = im.size[1],im.size[0],3
         return a
     if im.mode=="RGBA":
-        a = numpy.fromstring(im.tostring(),'B')
+        a = numpy.fromstring(im.tobytes(),'B')
         a.shape = im.size[1],im.size[0],4
         if not alpha: a = a[:,:,:3]
         return a


### PR DESCRIPTION
As of v3.0.x of Pillow baa5143394708704328dcd46b0387f36a276a762 the deprecated `tostring()` function is no longer an alias for `tobytes()`.

Tested this successfully with `./run-test` in two setups, one with Pillow 2.9.0 where it worked before and after the change, one with 3.0.0, where worked just with `tobytes()`
This should not conflict with any setup with a version of pillow >= 2.0