### PR TITLE
[gtedit] Use HTML file name instead of "Correction", #84

### DIFF
--- a/ocropus-gtedit
+++ b/ocropus-gtedit
@@ -181,7 +181,7 @@ if args.subparser_name=="html":
         P("<html>")
         P("<head>")
         P('<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />')
-        P('<title>Correction</title>')
+        P('<title>%s</title>', oname)
         P("</head>")
         P("<body>")
         for i,fname in enumerate(args.files):


### PR DESCRIPTION
Now, Firefox (and probably other browsers) will propose to use the
actual filename as the template for "Save page as".