### PR TITLE
firefox is not needed for ocropy to be installed

### DIFF
--- a/PACKAGES
+++ b/PACKAGES
@@ -1,1 +1,1 @@
-curl python-scipy python-matplotlib python-tables firefox imagemagick python-opencv python-bs4
+curl python-scipy python-matplotlib python-tables imagemagick python-opencv python-bs4


### PR DESCRIPTION
Installing firefox pulls in a lot of dependencies that are not needed in a headless setup.