### PR TITLE
opencv is used in the OLD scripts but not for the installed tools

### DIFF
--- a/PACKAGES
+++ b/PACKAGES
@@ -1,1 +1,1 @@
-curl python-scipy python-matplotlib python-tables firefox imagemagick python-opencv python-bs4
+curl python-scipy python-matplotlib python-tables firefox imagemagick python-bs4


### PR DESCRIPTION
This pulls in a lot of graphics dependencies that won't be used in the installed tools.