### PR TITLE
python setup.py install should not fail without models

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,14 +10,14 @@ from distutils.core import setup #, Extension, Command
 
 if not os.path.exists("models/en-default.pyrnn.gz"):
     print
-    print "You must download the default model 'en-default.pyrnn.gz'"
+    print "You should download the default model 'en-default.pyrnn.gz'"
     print "and put it into ./models."
     print
     print "Check https://github.com/tmbdev/ocropy for the location"
     print "of model files."
     print
-    sys.exit(1)
 
+models = [c for c in glob.glob("models/*pyrnn.gz")]
 scripts = [c for c in glob.glob("ocropus-*") if "." not in c and "~" not in c]
 
 setup(
@@ -26,6 +26,6 @@ setup(
     author = "Thomas Breuel",
     description = "The OCRopy RNN-based Text Line Recognizer",
     packages = ["ocrolib"],
-    data_files= [('share/ocropus', ["models/en-default.pyrnn.gz"])],
+    data_files= [('share/ocropus', models)],
     scripts = scripts,
     )


### PR DESCRIPTION
While it's sensible to remind the user to install a model and have available models at build time installed to /usr/share/ocropus, it should be possible to install ocropy without any models. They can always be provided via CLI flag.

This patch will install **all** `models/*.pyrnn.gz` files that are found, not just the default. But if none are found, it will still succeed.