### PR TITLE
nlbin: fix VisibleDeprecationWarning about non-integers

### DIFF
--- a/ocropus-nlbin
+++ b/ocropus-nlbin
@@ -164,7 +164,7 @@ def process1(job):
 
     # estimate low and high thresholds
     if args.parallel<2: print_info("estimating thresholds")
-    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    warnings.filterwarnings("ignore", category=VisibleDeprecationWarning)
     d0,d1 = flat.shape
     o0,o1 = int(args.bignore*d0),int(args.bignore*d1)
     est = flat[o0:d0-o0,o1:d1-o1]

--- a/ocropus-nlbin
+++ b/ocropus-nlbin
@@ -164,7 +164,6 @@ def process1(job):
 
     # estimate low and high thresholds
     if args.parallel<2: print_info("estimating thresholds")
-    warnings.filterwarnings("ignore", category=VisibleDeprecationWarning)
     d0,d1 = flat.shape
     o0,o1 = int(args.bignore*d0),int(args.bignore*d1)
     est = flat[o0:d0-o0,o1:d1-o1]
@@ -176,13 +175,12 @@ def process1(job):
         v = est-filters.gaussian_filter(est,e*20.0)
         v = filters.gaussian_filter(v**2,e*20.0)**0.5
         v = (v>0.3*amax(v))
-        v = morphology.binary_dilation(v,structure=ones((e*50,1)))
-        v = morphology.binary_dilation(v,structure=ones((1,e*50)))
+        v = morphology.binary_dilation(v,structure=ones((int(e*50),1)))
+        v = morphology.binary_dilation(v,structure=ones((1,int(e*50))))
         if args.debug>0: imshow(v); ginput(1,args.debug)
         est = est[v]
     lo = stats.scoreatpercentile(est.ravel(),args.lo)
     hi = stats.scoreatpercentile(est.ravel(),args.hi)
-    warnings.resetwarnings()
     # rescale the image to get the gray scale image
     if args.parallel<2: print_info("rescaling")
     flat -= lo

--- a/ocropus-nlbin
+++ b/ocropus-nlbin
@@ -8,7 +8,6 @@ from scipy.ndimage import filters,interpolation,morphology,measurements
 from scipy import stats
 import multiprocessing
 import ocrolib
-import warnings
 
 
 
@@ -26,7 +25,7 @@ parser.add_argument('-z','--zoom',type=float,default=0.5,help='zoom for page bac
 parser.add_argument('-e','--escale',type=float,default=1.0,help='scale for estimating a mask over the text region, default: %(default)s')
 parser.add_argument('-b','--bignore',type=float,default=0.1,help='ignore this much of the border for threshold estimation, default: %(default)s')
 parser.add_argument('-p','--perc',type=float,default=80,help='percentage for filters, default: %(default)s')
-parser.add_argument('-r','--range',type=float,default=20,help='range for filters, default: %(default)s')
+parser.add_argument('-r','--range',type=int,default=20,help='range for filters, default: %(default)s')
 parser.add_argument('-m','--maxskew',type=float,default=2,help='skew angle estimation parameters (degrees), default: %(default)s')
 parser.add_argument('-g','--gray',action='store_true',help='force grayscale processing even if image seems binary')
 parser.add_argument('--lo',type=float,default=5,help='percentile for black estimation, default: %(default)s')
@@ -135,7 +134,6 @@ def process1(job):
     else:
         # if not, we need to flatten it by estimating the local whitelevel
         if args.parallel<2: print_info("flattening")
-        warnings.filterwarnings("ignore", category=UserWarning)
         m = interpolation.zoom(image,args.zoom)
         m = filters.percentile_filter(m,args.perc,size=(args.range,2))
         m = filters.percentile_filter(m,args.perc,size=(2,args.range))
@@ -143,7 +141,6 @@ def process1(job):
         if args.debug>0: clf(); imshow(m,vmin=0,vmax=1); ginput(1,args.debug)
         w,h = minimum(array(image.shape),array(m.shape))
         flat = clip(image[:w,:h]-m[:w,:h]+1,0,1)
-        warnings.resetwarnings()
         if args.debug>0: clf(); imshow(flat,vmin=0,vmax=1); ginput(1,args.debug)
 
     # estimate skew angle and rotate


### PR DESCRIPTION
ocropus-nlbin causes

```
/usr/lib/python2.7/dist-packages/numpy/core/numeric.py:190: VisibleDeprecationWarning: using a non-integer number instead of an integer
 will result in an error in the future
  a = empty(shape, dtype, order)
```

and tries to suppress it:

```python
        v = morphology.binary_dilation(v,structure=ones((e*50,1)))
```

`e` is a float, so the first tuple element will also be a float. But it should be an integer.

numpy 1.11.0 at least outputs a `VisibleDeprecationWarning` which won't be filtered.