### PR TITLE
Replaces multi-var str() concat with %-format

### DIFF
--- a/ocropus-gpageseg
+++ b/ocropus-gpageseg
@@ -343,7 +343,7 @@ def process1(job):
             binary = ocrolib.read_image_binary(fname)
         except IOError:
             if ocrolib.trace: traceback.print_exc()
-            print_error("cannot open either " + base+".bin.png" + " or " + fname)
+            print_error("cannot open either %s.bin.png or %s" % (base, fname))
             return
 
     checktype(binary,ABINARY2)
@@ -351,7 +351,7 @@ def process1(job):
     if not args.nocheck:
         check = check_page(amax(binary)-binary)
         if check is not None:
-            print_error(fname + " SKIPPED " + check + " (use -n to disable this check)")
+            print_error("%s SKIPPED %s (use -n to disable this check)" % (fname, check))
             return
 
     if args.gray:
@@ -365,12 +365,12 @@ def process1(job):
         scale = psegutils.estimate_scale(binary)
     else:
         scale = args.scale
-    print_info("scale " + str(scale))
+    print_info("scale %f" % (scale))
     if isnan(scale) or scale>1000.0:
-        print_error("%s: bad scale (%g); skipping\n"%(fname,str(scale)))
+        print_error("%s: bad scale (%g); skipping\n" % (fname, scale))
         return
     if scale<args.minscale:
-        print_error("%s: scale (%s) less than --minscale; skipping\n"%(fname,str(scale)))
+        print_error("%s: scale (%g) less than --minscale; skipping\n" % (fname, scale))
         return
 
     # find columns and text lines
@@ -378,9 +378,9 @@ def process1(job):
     if not args.quiet: print_info("computing segmentation")
     segmentation = compute_segmentation(binary,scale)
     if amax(segmentation)>args.maxlines:
-        print_error(fname + ": too many lines" + str(amax(segmentation)))
+        print_error("%s too many lines %g" % (fname, amax(segmentation)))
         return
-    if not args.quiet: print_info("number of lines"+ str(amax(segmentation)))
+    if not args.quiet: print_info("number of lines %g" % amax(segmentation))
 
     # compute the reading order
 
@@ -410,7 +410,7 @@ def process1(job):
         if args.gray:
             grayline = psegutils.extract_masked(gray,l,pad=args.pad,expand=args.expand)
             ocrolib.write_image_gray("%s/01%04x.nrm.png"%(outputdir,i+1),grayline)
-    print_info("%6d "%i + fname + " %4.1f "%  + scale + " " + str(len(lines)))
+    print_info("%6d  %s %4.1f %d" % (i, fname,  scale,  len(lines)))
 
 if len(args.files)==1 and os.path.isdir(args.files[0]):
     files = glob.glob(args.files[0]+"/????.png")

--- a/ocropus-gpageseg
+++ b/ocropus-gpageseg
@@ -378,7 +378,7 @@ def process1(job):
     if not args.quiet: print_info("computing segmentation")
     segmentation = compute_segmentation(binary,scale)
     if amax(segmentation)>args.maxlines:
-        print_error("%s too many lines %g" % (fname, amax(segmentation)))
+        print_error("%s: too many lines %g" % (fname, amax(segmentation)))
         return
     if not args.quiet: print_info("number of lines %g" % amax(segmentation))
 

--- a/ocropus-nlbin
+++ b/ocropus-nlbin
@@ -106,15 +106,15 @@ def dshow(image,info):
 
 def process1(job):
     fname,i = job
-    print_info("#" + fname)
-    if args.parallel<2: print_info("=== "+fname+ " " +str(i))
+    print_info("# %s" % (fname))
+    if args.parallel<2: print_info("=== %s%-3d" % (fname, i))
     comment = ""
     raw = ocrolib.read_image_gray(fname)
     dshow(raw,"input")
     # perform image normalization
     image = raw-amin(raw)
     if amax(image)==amin(image):
-        print_info("# image is empty" + fname)
+        print_info("# image is empty: %s" % (fname))
         return
     image /= amax(image)
 
@@ -192,7 +192,7 @@ def process1(job):
     bin = 1*(flat>args.threshold)
 
     # output the normalized grayscale and the thresholded images
-    print_info(fname+" lo-hi (%.2f %.2f) angle %4.1f"%(lo,hi,angle) + comment)
+    print_info("%s lo-hi (%.2f %.2f) angle %4.1f %s" % (fname, lo, hi, angle, comment))
     if args.parallel<2: print_info("writing")
     if args.debug>0 or args.show: clf(); gray();imshow(bin); ginput(1,max(0.1,args.debug))
     if args.output:

--- a/ocropus-nlbin
+++ b/ocropus-nlbin
@@ -107,8 +107,7 @@ def dshow(image,info):
 def process1(job):
     fname,i = job
     print_info("# %s" % (fname))
-    if args.parallel<2: print_info("=== %s%-3d" % (fname, i))
-    comment = ""
+    if args.parallel<2: print_info("=== %s %-3d" % (fname, i))
     raw = ocrolib.read_image_gray(fname)
     dshow(raw,"input")
     # perform image normalization
@@ -130,9 +129,10 @@ def process1(job):
     else:
         extreme = (sum(image<0.05)+sum(image>0.95))*1.0/prod(image.shape)
     if extreme>0.95:
-        comment += " no-normalization"
+        comment = "no-normalization"
         flat = image
     else:
+        comment = ""
         # if not, we need to flatten it by estimating the local whitelevel
         if args.parallel<2: print_info("flattening")
         warnings.filterwarnings("ignore", category=UserWarning)

--- a/ocropus-rpred
+++ b/ocropus-rpred
@@ -286,7 +286,7 @@ if args.estrate:
         terr += err
         total += n
         confusions += conf
-    print_info("%.5f %d %d %d" % (terr*1.0/total, terr, total, args.model))
+    print_info("%.5f %d %d %s" % (terr*1.0/total, terr, total, args.model))
     if args.estconf>0:
         print_info("top %d confusions (count pred gt), comparison: %s" % (
             args.estconf, args.compare))

--- a/ocropus-rpred
+++ b/ocropus-rpred
@@ -96,7 +96,7 @@ print_info("")
 
 
 inputs = ocrolib.glob_all(args.files)
-if not args.quiet: print_info("#inputs"+ str(len(inputs)))
+if not args.quiet: print_info("#inputs: %d" % (len(inputs)))
 
 # disable parallelism when anything is being displayed
 
@@ -140,7 +140,7 @@ def process1(arg):
     if not args.nocheck:
         check = check_line(amax(line)-line)
         if check is not None:
-            print_error(fname+" SKIPPED "+check+" (use -n to disable this check)")
+            print_error("%s SKIPPED %s (use -n to disable this check)" % (fname, check))
             return (0,[],0,trial,fname)
 
     if not args.nolineest:
@@ -198,7 +198,7 @@ def process1(arg):
             err = edist.xlevenshtein(pred0,gt0)
             conf = []
         if not args.quiet:
-            print_info("%3d %3d"%(err,len(gt)) + " " + fname+":"+pred)
+            print_info("%3d %3d %s:%s" % (err, len(gt), fname, pred))
             sys.stdout.flush()
         return (err,conf,len(gt0),trial,fname)
 
@@ -286,8 +286,9 @@ if args.estrate:
         terr += err
         total += n
         confusions += conf
-    print_info("%.5f"%(terr*1.0/total) + " " + terr+ " " + total + " " + args.model)
+    print_info("%.5f %d %d %d" % (terr*1.0/total, terr, total, args.model))
     if args.estconf>0:
-        print_info("top " + args.estconf + " confusions (count pred gt), comparison: " + args.compare)
+        print_info("top %d confusions (count pred gt), comparison: %s" % (
+            args.estconf, args.compare))
         for ((u,v),n) in Counter(confusions).most_common(args.estconf):
-            print_info("%6d %-4s %-4s"%(n,u,v))
+            print_info("%6d %-4s %-4s" % (n, u ,v))


### PR DESCRIPTION
This cleans up the print_* calls in those files that redundantly cast numbers to string (as mentioned in #103)

```python
"%s" % (str(1))
# ->
"%d" % (1)

fname+": %d" % 3
# ->
"%s: %d" % (fname, 3)
```