### PR TITLE
Raise a ValueError for non-binarized images, #127 #55

### DIFF
--- a/ocrolib/common.py
+++ b/ocrolib/common.py
@@ -216,6 +216,11 @@ def isintarray(a):
 def isintegerarray(a):
     return a.dtype in [dtype('int32'),dtype('int64'),dtype('uint32'),dtype('uint64')]
 
+def isbinarized(a):
+    """Tests whether an array has only two unique values 0 and 1"""
+    a = sorted(unique(a))
+    return len(a) == 2 and a[0] == 0 and a[1] == 1
+
 @checks(str,pageno=int,_=GRAYSCALE)
 def read_image_gray(fname,pageno=0):
     """Read an image and returns it as a floating point array.

--- a/ocropus-lpred
+++ b/ocropus-lpred
@@ -80,6 +80,8 @@ for trial in range(len(inputs)):
         fname = inputs[trial]
         base,_ = ocrolib.allsplitext(fname)
         line = ocrolib.read_image_gray(fname)
+        if not ocrolib.isbinarized(line):
+            raise ValueError("Image %s is not binarized" % (fname))
         line = preprocess(line)
         if line is None: continue
         outputs = array(network.forward(line))

--- a/ocropus-ltrain
+++ b/ocropus-ltrain
@@ -96,6 +96,8 @@ for trial in range(args.start,args.ntrain):
         fname = inputs[randint(0,len(inputs))]
         base,_ = ocrolib.allsplitext(fname)
         line = ocrolib.read_image_gray(fname)
+        if not ocrolib.isbinarized(line):
+            raise ValueError("Image %s is not binarized" % (fname))
         transcript = ocrolib.read_text(base+".gt.txt")
         print "#",trial,fname,line.shape
         line = preprocess(line)

--- a/ocropus-rpred
+++ b/ocropus-rpred
@@ -133,6 +133,8 @@ def process1(arg):
     (trial,fname) = arg
     base,_ = ocrolib.allsplitext(fname)
     line = ocrolib.read_image_gray(fname)
+    if not ocrolib.isbinarized(line):
+        raise ValueError("Image %s is not binarized" % (fname))
     raw_line = line.copy()
     if prod(line.shape)==0: return None
     if amax(line)==amin(line): return None

--- a/ocropus-rtrain
+++ b/ocropus-rtrain
@@ -261,6 +261,8 @@ for trial in range(start,args.ntrain):
     base,_ = ocrolib.allsplitext(fname)
     try:
         line = ocrolib.read_image_gray(fname)
+        if not ocrolib.isbinarized(line):
+            raise ValueError("Image %s is not binarized" % (fname))
         transcript = ocrolib.read_text(base+".gt.txt")
     except IOError as e:
         print "ERROR",e


### PR DESCRIPTION
Simple checks to ensure that images loaded for training / recognition are black and white.
