### PR TITLE
Add new option --probabilities in ocropus-rpred

### DIFF
--- a/ocrolib/lstm.py
+++ b/ocrolib/lstm.py
@@ -745,8 +745,12 @@ def translate_back0(outputs,threshold=0.25):
 from scipy.ndimage import measurements,filters
 
 def translate_back(outputs,threshold=0.7,pos=0):
-    """Translate back. Thresholds on class 0, then assigns
-    the maximum class to each region."""
+    """Translate back. Thresholds on class 0, then assigns the maximum class to
+    each region. ``pos`` determines the depth of character information returned:
+        * `pos=0`: Return list of recognized characters
+        * `pos=1`: Return list of position-character tuples
+        * `pos=2`: Return list of character-probability tuples
+     """
     labels,n = measurements.label(outputs[:,0]<threshold)
     mask = tile(labels.reshape(-1,1),(1,outputs.shape[1]))
     maxima = measurements.maximum_position(outputs,mask,arange(1,amax(mask)+1))

--- a/ocrolib/lstm.py
+++ b/ocrolib/lstm.py
@@ -753,7 +753,7 @@ def translate_back(outputs,threshold=0.7,pos=0):
     if pos: return maxima
     return [c for (r,c) in maxima]
 
-def translate_back_with_alternates(orig_outputs, threshold=0.7, alt_threshold=0.1):
+def translate_back_with_probabilities(orig_outputs, threshold=0.7):
     """Like translate_back, but returns a list of possibilities at each pos.
 
     Output is a list of [(letter1, score1), (letter2, score2), ...].
@@ -762,22 +762,13 @@ def translate_back_with_alternates(orig_outputs, threshold=0.7, alt_threshold=0.
     labels, n = measurements.label(outputs[:,0] < threshold)
     mask = tile(labels.reshape(-1, 1), (1, outputs.shape[1]))
 
-    outputs[:,0] = 0
-    outputs[mask == 0] = 0
     out_scores = []
-    while outputs.max() > alt_threshold:
-        maxima = measurements.maximum_position(outputs, mask, arange(1,amax(mask)+1))
-        scores = [(c, outputs[r,c]) for r, c in maxima]
-        out_scores.append(scores)
-
-        # Clear the max cols to expose the next-highest values.
-        for i, (r, c) in enumerate(maxima):
-            col_mask = np.zeros(outputs.shape)
-            col_mask[:,c] = 1
-            outputs[mask * col_mask == i+1] = 0
+    maxima = measurements.maximum_position(outputs, mask, arange(1,amax(mask)+1))
+    scores = [(c, outputs[r,c]) for r, c in maxima]
+    out_scores.append(scores)
 
     scores = zip(*out_scores)
-    return [[(c, score) for c, score in char if score > alt_threshold]
+    return [[(c, score) for c, score in char]
             for char in scores]
 
 

--- a/ocrolib/lstm.py
+++ b/ocrolib/lstm.py
@@ -750,27 +750,9 @@ def translate_back(outputs,threshold=0.7,pos=0):
     labels,n = measurements.label(outputs[:,0]<threshold)
     mask = tile(labels.reshape(-1,1),(1,outputs.shape[1]))
     maxima = measurements.maximum_position(outputs,mask,arange(1,amax(mask)+1))
-    if pos: return maxima
-    return [c for (r,c) in maxima]
-
-def translate_back_with_probabilities(orig_outputs, threshold=0.7):
-    """Like translate_back, but returns a list of possibilities at each pos.
-
-    Output is a list of [(letter1, score1), (letter2, score2), ...].
-    """
-    outputs = orig_outputs.copy()
-    labels, n = measurements.label(outputs[:,0] < threshold)
-    mask = tile(labels.reshape(-1, 1), (1, outputs.shape[1]))
-
-    out_scores = []
-    maxima = measurements.maximum_position(outputs, mask, arange(1,amax(mask)+1))
-    scores = [(c, outputs[r,c]) for r, c in maxima]
-    out_scores.append(scores)
-
-    scores = zip(*out_scores)
-    return [[(c, score) for c, score in char]
-            for char in scores]
-
+    if pos==1: return maxima # include character position
+    if pos==2: return [(c, outputs[r,c]) for (r,c) in maxima] # include character probabilities
+    return [c for (r,c) in maxima] # only recognized characters
 
 def log_mul(x,y):
     "Perform multiplication in the log domain (i.e., addition)."

--- a/ocrolib/lstm.py
+++ b/ocrolib/lstm.py
@@ -753,6 +753,34 @@ def translate_back(outputs,threshold=0.7,pos=0):
     if pos: return maxima
     return [c for (r,c) in maxima]
 
+def translate_back_with_alternates(orig_outputs, threshold=0.7, alt_threshold=0.1):
+    """Like translate_back, but returns a list of possibilities at each pos.
+
+    Output is a list of [(letter1, score1), (letter2, score2), ...].
+    """
+    outputs = orig_outputs.copy()
+    labels, n = measurements.label(outputs[:,0] < threshold)
+    mask = tile(labels.reshape(-1, 1), (1, outputs.shape[1]))
+
+    outputs[:,0] = 0
+    outputs[mask == 0] = 0
+    out_scores = []
+    while outputs.max() > alt_threshold:
+        maxima = measurements.maximum_position(outputs, mask, arange(1,amax(mask)+1))
+        scores = [(c, outputs[r,c]) for r, c in maxima]
+        out_scores.append(scores)
+
+        # Clear the max cols to expose the next-highest values.
+        for i, (r, c) in enumerate(maxima):
+            col_mask = np.zeros(outputs.shape)
+            col_mask[:,c] = 1
+            outputs[mask * col_mask == i+1] = 0
+
+    scores = zip(*out_scores)
+    return [[(c, score) for c, score in char if score > alt_threshold]
+            for char in scores]
+
+
 def log_mul(x,y):
     "Perform multiplication in the log domain (i.e., addition)."
     return x+y

--- a/ocropus-rpred
+++ b/ocropus-rpred
@@ -3,7 +3,6 @@ from __future__ import print_function
 import traceback
 import codecs
 from pylab import *
-import json
 import os.path
 import ocrolib
 import argparse
@@ -57,8 +56,8 @@ parser.add_argument("-q","--quiet",action="store_true",
                     help="turn off most output")
 parser.add_argument("-Q","--parallel",type=int,default=1,
                     help="number of parallel processes to use, default: %(default)s")
-parser.add_argument('--alternates', action='store_true',
-                    help='Output JSON file with scores and alternate characters.')
+parser.add_argument('--probabilities', action='store_true',
+                    help='Output probabilities for each letter')
 
 # input files
 parser.add_argument("files",nargs="+",
@@ -185,11 +184,15 @@ def process1(arg):
                     r = (r-args.pad)*scale
                     locs.write("%s\t%.1f\n"%(c,r))
 
-    if args.alternates:
-        alts = lstm.translate_back_with_alternates(network.outputs)
+    if args.probabilities:
+        alts = lstm.translate_back_with_probabilities(network.outputs)
         chars = [[(network.l2s([c]), score) for c, score in char if c > 0]
                     for char in alts]
-        json.dump(chars, open(base + '.alts.json', 'w'), indent=2)
+        with codecs.open(base+".prob","w") as locs:
+		for char in alts:
+			for p,s in char:
+				l = network.l2s([p])
+				locs.write("%s\t%s\t%s\n"%(l,p,s))
 
     if not args.nonormalize:
         pred = ocrolib.normalize_text(pred)

--- a/ocropus-rpred
+++ b/ocropus-rpred
@@ -36,6 +36,8 @@ parser.add_argument('--llocs',action="store_true",
                     help="output LSTM locations for characters")
 parser.add_argument('--alocs',action="store_true",
                     help="output aligned LSTM locations for characters")
+parser.add_argument('--probabilities',action="store_true",
+                    help="output probabilities for each letter")
 
 # error measures
 parser.add_argument("-r","--estrate",action="store_true",
@@ -56,8 +58,6 @@ parser.add_argument("-q","--quiet",action="store_true",
                     help="turn off most output")
 parser.add_argument("-Q","--parallel",type=int,default=1,
                     help="number of parallel processes to use, default: %(default)s")
-parser.add_argument('--probabilities', action='store_true',
-                    help='Output probabilities for each letter')
 
 # input files
 parser.add_argument("files",nargs="+",
@@ -185,14 +185,12 @@ def process1(arg):
                     locs.write("%s\t%.1f\n"%(c,r))
 
     if args.probabilities:
-        alts = lstm.translate_back_with_probabilities(network.outputs)
-        chars = [[(network.l2s([c]), score) for c, score in char if c > 0]
-                    for char in alts]
-        with codecs.open(base+".prob","w") as locs:
-		for char in alts:
-			for p,s in char:
-				l = network.l2s([p])
-				locs.write("%s\t%s\t%s\n"%(l,p,s))
+        # output character probabilities
+        result = lstm.translate_back(network.outputs,pos=2)
+        with codecs.open(base+".prob","w","utf-8") as file:
+            for c,p in result:
+                c = network.l2s([c])
+                file.write("%s\t%s\n"%(c,p))
 
     if not args.nonormalize:
         pred = ocrolib.normalize_text(pred)

--- a/ocropus-rpred
+++ b/ocropus-rpred
@@ -3,6 +3,7 @@ from __future__ import print_function
 import traceback
 import codecs
 from pylab import *
+import json
 import os.path
 import ocrolib
 import argparse
@@ -56,6 +57,8 @@ parser.add_argument("-q","--quiet",action="store_true",
                     help="turn off most output")
 parser.add_argument("-Q","--parallel",type=int,default=1,
                     help="number of parallel processes to use, default: %(default)s")
+parser.add_argument('--alternates', action='store_true',
+                    help='Output JSON file with scores and alternate characters.')
 
 # input files
 parser.add_argument("files",nargs="+",
@@ -181,6 +184,12 @@ def process1(arg):
                     c = network.l2s([c])
                     r = (r-args.pad)*scale
                     locs.write("%s\t%.1f\n"%(c,r))
+
+    if args.alternates:
+        alts = lstm.translate_back_with_alternates(network.outputs)
+        chars = [[(network.l2s([c]), score) for c, score in char if c > 0]
+                    for char in alts]
+        json.dump(chars, open(base + '.alts.json', 'w'), indent=2)
 
     if not args.nonormalize:
         pred = ocrolib.normalize_text(pred)


### PR DESCRIPTION
This PR will give `ocropus-rpred` a new option `--probabilities` which will additionally save for each line a file `.prob` which contains the character probabilities, e.g.
```
root@939002a1af8e:/ocropy# ocropus-rpred tests/1175-01002b.png --probabilities
INFO:
INFO:  ########## /usr/local/bin/ocropus-rpred tests/1175-01002b.png --probabi
INFO:
INFO:  #inputs: 1
# loading object /usr/local/share/ocropus/en-default.pyrnn.gz
INFO:  tests/1175-01002b.png:crcasing oricntation dispersion of a single sct of
```
which will also save the file `1175-01002b.prob` which looks like
```
c	0.979626931378
r	0.995782592762
c	0.947235609157
a	0.996203434919
s	0.991683733363
i	0.993947589753
n	0.994791900459
g	0.966814216763
 	0.995118403987
o	0.99320397717
r	0.992937184296
i	0.995907285691
c	0.703712835111
n	0.99234998498
t	0.992499281063
...
```
I simplified [my previous work](https://github.com/zuphilip/ocropy/tree/probabilities) quite a bit and tried to integrate it better into the existing code. The whole idea is based on some code by @danvk and there are several issues, where people ask about a possibility to access character level probabilities/confidences, see e.g. #87.