### PR TITLE
[WIP] Customizable vertical separators

### DIFF
--- a/ocropus-gpageseg
+++ b/ocropus-gpageseg
@@ -149,7 +149,7 @@ def DSAVE(title,image):
 def compute_separators_morph(binary,scale):
     """Finds vertical black lines corresponding to column separators."""
     d0 = int(max(5,scale/4))
-    d1 = int(max(5,scale))+args.sepwiden
+    d1 = int(max(5,scale/4)) + args.sepwiden
     thick = morph.r_dilation(binary,(d0,d1))
     vert = morph.rb_opening(thick,(10*scale,1))
     vert = morph.r_erosion(vert,(d0//2,args.sepwiden))

--- a/ocropus-gpageseg
+++ b/ocropus-gpageseg
@@ -205,7 +205,7 @@ def compute_colseps_conv(binary,scale=1.0):
     grad = (grad>0.5*amax(grad))
     DSAVE("2grad",grad)
     # combine edges and whitespace
-    seps = minimum(thresh,maximum_filter(grad,(int(scale),int(5*scale))))
+    seps = minimum(thresh,maximum_filter(grad,(int(5*scale),int(5*scale))))
     seps = maximum_filter(seps,(int(2*scale),1))
     DSAVE("3seps",seps)
     # select only the biggest column separators


### PR DESCRIPTION
This  branch contains the pertinent commits from #68 for now

Comments from that PR:

https://github.com/tmbdev/ocropy/pull/68#issue-117885401:
> I work a lot with bordered tables and observed damaged characters near the left and right cell borders. I think the vertical separators are expanded too much.

https://github.com/tmbdev/ocropy/pull/68#issuecomment-176446204:
<blockquote>
That looks useful, but could you please make these values into command line parameters? I'm reluctant to change them because it would require extensive testing to figure out how that affects other page segmentation (since I currently don't have a setup for testing this easily on large datasets).

Something like:
```
d1 = int(max(5,args.separator_multiplier_h * scale)) + args.sepwiden
seps = minimum(thresh,maximum_filter(grad,(int(args.septhresh_multiplier_h*scale),int(5*scale))))
The defaults should just be 1.0
```
Eventually, this code will get replaced by trainable 2D LSTM models.
</blockquote>