### PR TITLE
Clip exponential in ffunc to avoid overflow

### DIFF
--- a/ocrolib/lstm.py
+++ b/ocrolib/lstm.py
@@ -380,7 +380,8 @@ class MLP(Network):
 
 def ffunc(x):
     "Nonlinearity used for gates."
-    return 1.0/(1.0+exp(-x))
+    # cliping to avoid overflows
+    return 1.0/(1.0+exp(clip(-x,-20,20)))
 def fprime(x,y=None):
     "Derivative of nonlinearity used for gates."
     if y is None: y = sigmoid(x)


### PR DESCRIPTION
This should avoid (hopefully) some possible FloatingPointError overflow errors.

The sigmoid function ffunc is for any x<-20 and x>20 already 0 resp. 1 up to 10^-9
and cutting will therefore not change the function substantially.

This idea is from @tmbdev in https://github.com/tmbdev/ocropy/issues/5#issuecomment-65329170
Implemented first in https://github.com/tmbdev/ocropy/issues/49#issuecomment-139919235
Additional infos from https://github.com/tmbdev/ocropy/issues/79#issue-126999594