### PR TITLE
Change checks for write_page_segmentation

### DIFF
--- a/ocrolib/common.py
+++ b/ocrolib/common.py
@@ -279,7 +279,6 @@ def read_page_segmentation(fname):
     segmentation = make_seg_black(segmentation)
     return segmentation
 
-@checks(str,PAGESEG)
 def write_page_segmentation(fname,image):
     """Writes a page segmentation, that is an RGB image whose values
     encode the segmentation of a page."""


### PR DESCRIPTION
This seems to solve #88 and allows to run page segmentation also in smaller images (less than 600x600), by using the `-n` option which deactivate the checks. The function `write_page_segmentation` should IMO not depend on the size of the image. Moreover, the check is now equal to the one for the function `read_page_segmentation` (cf. some lines above).