### PR TITLE
Update PACKAGES - Add additional package for SciPy dependency

### DIFF
--- a/PACKAGES
+++ b/PACKAGES
@@ -1,1 +1,1 @@
-python-scipy python-matplotlib python-lxml
+python-scipy python-matplotlib python-lxml libatlas-base-dev


### PR DESCRIPTION
Additional "libatlas-base-dev" package is required to fix the following error. I.e. It's a dependency for sci-py

```sh
./repos/ocropy/ocropus-nlbin --help
Traceback (most recent call last):
  File "./repos/ocropy/ocropus-nlbin", line 8, in <module>
    from scipy.ndimage import filters,interpolation,morphology,measurements
  File "/usr/local/lib/python2.7/dist-packages/scipy/ndimage/__init__.py", line 172, in <module>
    from .filters import *
  File "/usr/local/lib/python2.7/dist-packages/scipy/ndimage/filters.py", line 37, in <module>
    from scipy.misc import doccer
  File "/usr/local/lib/python2.7/dist-packages/scipy/misc/__init__.py", line 49, in <module>
    from scipy.special import comb, factorial, factorial2, factorialk
  File "/usr/local/lib/python2.7/dist-packages/scipy/special/__init__.py", line 601, in <module>
    from ._ufuncs import *
ImportError: libf77blas.so.3: cannot open shared object file: No such file or directory
```