### PR TITLE
Changed method 'read_image_gray()' and 'read_image_binary()'. The old…

### DIFF
--- a/ocrolib/common.py
+++ b/ocrolib/common.py
@@ -152,7 +152,7 @@ def isintarray(a):
 def isintegerarray(a):
     return a.dtype in [dtype('int32'),dtype('int64'),dtype('uint32'),dtype('uint64')]
 
-@checks(str,pageno=int,_=GRAYSCALE)
+@checks({str,object},pageno=int,_=GRAYSCALE)
 def read_image_gray(fname,pageno=0):
     """Read an image and returns it as a floating point array.
     The optional page number allows images from files containing multiple
@@ -160,7 +160,10 @@ def read_image_gray(fname,pageno=0):
     the range 0...1 (unsigned) or -1...1 (signed)."""
     if type(fname)==tuple: fname,pageno = fname
     assert pageno==0
-    pil = PIL.Image.open(fname)
+    if type(fname) == PIL.Image.Image:
+        pil = fname
+    else:
+        pil = PIL.Image.open(fname)
     a = pil2array(pil)
     if a.dtype==dtype('uint8'):
         a = a/255.0
@@ -191,13 +194,16 @@ def write_image_gray(fname,image,normalize=0,verbose=0):
     im = array2pil(image)
     im.save(fname)
 
-@checks(str,_=ABINARY2)
+@checks({str,object},_=ABINARY2)
 def read_image_binary(fname,dtype='i',pageno=0):
     """Read an image from disk and return it as a binary image
     of the given dtype."""
     if type(fname)==tuple: fname,pageno = fname
     assert pageno==0
-    pil = PIL.Image.open(fname)
+    if type(fname) == PIL.Image.Image
+        pil = fname
+    else:
+        pil = PIL.Image.open(fname)
     a = pil2array(pil)
     if a.ndim==3: a = amax(a,axis=2)
     return array(a>0.5*(amin(a)+amax(a)),dtype)


### PR DESCRIPTION
Goal: Extend the ability to process image only from disk to from both disk and memory.

Updates: changed methods 'read_image_gray()' and 'read_image_binary' in module 'ocrlib/common.py'. 

Description: The method can only read an image from disk i.e. from a filename (string). The new method extends the ability to read an image from both disk and memory. Read image from memory means that it can also accept file object or PIL.Image.Image object as the parameter of this method.

My application context: Now I developed OCRopus related services and used the library 'ocrlib', but it can only read an image from disk (the parameter type must be 'string'). While for my service, I used the Django framework, which receives the image uploaded by users as an 'InMemoryUploadFile' type which is a file type object. Thus, the 'ocrlib' can not take it as a parameter of the read_image_ methods and thus cannot process. So I changed the methods and now it can process image from disk (string type) and memory (file object or PIL.Image.Image) 