### PR TITLE
Have pageseg output decimal rather than hex numbering

### DIFF
--- a/ocropus-gpageseg
+++ b/ocropus-gpageseg
@@ -444,10 +444,10 @@ def process1(job):
     cleaned = ocrolib.remove_noise(binary,args.noise)
     for i,l in enumerate(lines):
         binline = psegutils.extract_masked(1-cleaned,l,pad=args.pad,expand=args.expand)
-        ocrolib.write_image_binary("%s/01%04x.bin.png"%(outputdir,i+1),binline)
+        ocrolib.write_image_binary("%s/01%04d.bin.png"%(outputdir,i+1),binline)
         if args.gray:
             grayline = psegutils.extract_masked(gray,l,pad=args.pad,expand=args.expand)
-            ocrolib.write_image_gray("%s/01%04x.nrm.png"%(outputdir,i+1),grayline)
+            ocrolib.write_image_gray("%s/01%04d.nrm.png"%(outputdir,i+1),grayline)
     print_info("%6d  %s %4.1f %d" % (i, fname,  scale,  len(lines)))
 
 if len(args.files)==1 and os.path.isdir(args.files[0]):


### PR DESCRIPTION
This is useful as it means that normal alphabetical ordering of files works as expected. This allows one to do things like `cat *txt >wholepage.txt` to get a complete transcription of a page.