### PR TITLE
Bump version to 1.3.2

### DIFF
--- a/ocrolib/hocr.py
+++ b/ocrolib/hocr.py
@@ -14,7 +14,7 @@ header_template = """\
 <head>
 <title>OCR Results</title>
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-<meta name="ocr-system" content="ocropy-1.0" />
+<meta name="ocr-system" content="ocropy-1.3.2" />
 <meta name="ocr-capabilities" content="ocr_line ocr_page" />
 </head>
 <body>

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ scripts = [c for c in glob.glob("ocropus-*") if "." not in c and "~" not in c]
 
 setup(
     name = 'ocropy',
-    version = 'v1.0',
+    version = 'v1.3.2',
     author = "Thomas Breuel",
     description = "The OCRopy RNN-based Text Line Recognizer",
     packages = ["ocrolib"],


### PR DESCRIPTION
New tags/releases were created now retroperspectively, but we should try to continue that better just in time. With the new commit which gets rid of the native code, we can plan a new version 1.3.2.

This is on hold until #269 is solved. Any more testing of the current state would also be appreciated.

(After merging this commit can then be tagged with `v1.3.2`.)