### PR TITLE
Added option to load training data through file

### DIFF
--- a/ocropus-rtrain
+++ b/ocropus-rtrain
@@ -73,7 +73,7 @@ parser.add_argument("-Q","--nocheck",action="store_true")
 parser.add_argument("-p","--pad",type=int,default=16)
 
 # add file
-parser.add_argument("-f","--file",default=None,help="input the training data as a file list")
+parser.add_argument("-f","--file",default=None,help="path to file listing input files, one per line")
 
 parser.add_argument("files",nargs="*")
 args = parser.parse_args()

--- a/ocropus-rtrain
+++ b/ocropus-rtrain
@@ -72,10 +72,20 @@ parser.add_argument("-q","--quiet",action="store_true")
 parser.add_argument("-Q","--nocheck",action="store_true")
 parser.add_argument("-p","--pad",type=int,default=16)
 
+# add file
+parser.add_argument("-f","--file",default=None,help="input the training data as a file list")
+
 parser.add_argument("files",nargs="*")
 args = parser.parse_args()
 
 inputs = ocrolib.glob_all(args.files)
+
+if args.file is not None:
+    print("getting training data from file")
+    with open(args.file) as file:
+        for l in file:
+            inputs.append(l.rstrip())
+
 if len(inputs)==0:
     parser.print_help()
     sys.exit(0)

--- a/run-test-ci
+++ b/run-test-ci
@@ -1,5 +1,12 @@
 #!/bin/bash -e
 
+# Usage: ./run-test-ci [tests...]
+#
+# Examples:
+#
+#    ./run-test-ci              # Run all tests
+#    ./run-test-ci page conf    # Run only 'test_page' and 'test_conf'
+#
 BASE=$(dirname $0)
 
 # 'RUNNER' is the binary that the scripts are executed by. It defaults to
@@ -61,6 +68,13 @@ test_rtrain() {
     $RUNNER $BASE/ocropus-rtrain 'book/*/*.bin.png' -N 5 -o ci-test-model
 }
 
+test_rtrain_files() {
+    tar -zxf $BASE/tests/uw3-500.tgz
+    find 'book' -name '*.bin.png' > INPUT_FILES
+    $RUNNER $BASE/ocropus-rtrain -f INPUT_FILES -N 5 -o ci-test-model
+    rm INPUT_FILES
+}
+
 test_nlbin() {
     local TESTIMAGE=0071-010012.png
     cp $BASE/tests/$TESTIMAGE temp
@@ -100,11 +114,18 @@ test_gtedit() {
 
 rm -rf temp
 mkdir -p temp
-test_page
-test_conf
-test_linegen
-test_rtrain
-test_nlbin
-test_gpageseg
-test_rpred
-test_gtedit
+if (( $# > 0 ));then
+    for test in "$@";do
+        test_$test
+    done
+else
+    test_page
+    test_conf
+    test_linegen
+    test_rtrain
+    test_rtrain_files
+    test_nlbin
+    test_gpageseg
+    test_rpred
+    test_gtedit
+fi


### PR DESCRIPTION
Together with @uvius I added the option to pass the training images through a file, avoiding the "Argument list too long" error when passing too many files.

This allows the user to pass as many files as he wants to ocropus-rtrain, avoiding the `argument list too long` error of the shell, as in Issue #93.