### PR TITLE
gpageseg: Option to output line boxes as kraken-compatible JSON

### DIFF
--- a/ocrolib/psegutils.py
+++ b/ocrolib/psegutils.py
@@ -121,6 +121,16 @@ def extract_masked(image,linedesc,pad=5,expand=0):
     line = where(mask,line,amax(line))
     return line
 
+def lindedesc_as_list(linedesc, pad=5):
+    """
+    Convert a line segmentation into the JSON format used by kraken
+    """
+    y0,x0,y1,x1 = [int(x) for x in [
+        linedesc.bounds[0].start, linedesc.bounds[1].start,
+        linedesc.bounds[0].stop, linedesc.bounds[1].stop
+    ]]
+    return (x0-pad,y0-pad,x1+pad,y1+pad)
+
 def reading_order(lines,highlight=None,debug=0):
     """Given the list of lines (a list of 2D slices), computes
     the partial reading order.  The output is a binary 2D array

--- a/ocropus-gpageseg
+++ b/ocropus-gpageseg
@@ -19,6 +19,7 @@ import os
 import os.path
 import sys
 import traceback
+import json
 from multiprocessing import Pool
 
 import numpy as np
@@ -30,6 +31,7 @@ import ocrolib
 from ocrolib import psegutils,morph,sl
 from ocrolib.exceptions import OcropusException
 from ocrolib.toplevel import *
+from ocrolib.psegutils import B
 
 parser = argparse.ArgumentParser(add_help=False)
 
@@ -90,6 +92,8 @@ group_output.add_argument('-p','--pad',type=int,default=3,
                     help='padding for extracted lines, default: %(default)s')
 group_output.add_argument('-e','--expand',type=int,default=3,
                     help='expand mask for grayscale extraction, default: %(default)s')
+group_output.add_argument('--kraken',action='store_true',
+                    help='produce kraken-compatible segmentation output instead of masked images, default: %(default)s')
 
 # other parameters
 group_others = parser.add_argument_group('others')
@@ -149,10 +153,6 @@ print_info("")
 if args.parallel>1:
     args.quiet = 1
 
-
-def B(a):
-    if a.dtype==np.dtype('B'): return a
-    return np.array(a,'B')
 
 
 def DSAVE(title,image):
@@ -440,14 +440,22 @@ def process1(job):
     if not os.path.exists(outputdir):
         os.mkdir(outputdir)
     lines = [lines[i] for i in lsort]
-    ocrolib.write_page_segmentation("%s.pseg.png"%outputdir,segmentation)
-    cleaned = ocrolib.remove_noise(binary,args.noise)
-    for i,l in enumerate(lines):
-        binline = psegutils.extract_masked(1-cleaned,l,pad=args.pad,expand=args.expand)
-        ocrolib.write_image_binary("%s/01%04x.bin.png"%(outputdir,i+1),binline)
-        if args.gray:
-            grayline = psegutils.extract_masked(gray,l,pad=args.pad,expand=args.expand)
-            ocrolib.write_image_gray("%s/01%04x.nrm.png"%(outputdir,i+1),grayline)
+    if (args.kraken):
+        with open("%s.json" % (outputdir), "w") as jsonfile:
+            jsonfile.write(json.dumps({
+                "text_direction": "horizontal-lr",
+                "script_detection": False,
+                "boxes": [psegutils.lindedesc_as_list(l, pad=args.pad) for l in lines]
+            }))
+    else:
+        ocrolib.write_page_segmentation("%s.pseg.png"%outputdir,segmentation)
+        cleaned = ocrolib.remove_noise(binary,args.noise)
+        for i,l in enumerate(lines):
+            binline = psegutils.extract_masked(1-cleaned,l,pad=args.pad,expand=args.expand)
+            ocrolib.write_image_binary("%s/01%04x.bin.png"%(outputdir,i+1),binline)
+            if args.gray:
+                grayline = psegutils.extract_masked(gray,l,pad=args.pad,expand=args.expand)
+                ocrolib.write_image_gray("%s/01%04x.nrm.png"%(outputdir,i+1),grayline)
     print_info("%6d  %s %4.1f %d" % (i, fname,  scale,  len(lines)))
 
 if len(args.files)==1 and os.path.isdir(args.files[0]):


### PR DESCRIPTION
This allows feeding the results of ocropy's segmentation into the recognition of kraken. It's also a useful format to postprocess the segmentation results, e.g. creating line images for ground truth on your own.