### PR TITLE
Add NFC and NFD normalization options (keeping NFKC as the default)

### DIFF
--- a/ocrolib/lstm.py
+++ b/ocrolib/lstm.py
@@ -837,6 +837,12 @@ def ctc_align_targets(outputs,targets,threshold=100.0,verbose=0,debug=0,lo=1e-5)
         plt.ginput(1,0.01);
     return aligned
 
+def normalize_nfc(s):
+    return unicodedata.normalize('NFC',s)
+
+def normalize_nfd(s):
+    return unicodedata.normalize('NFD',s)
+
 def normalize_nfkc(s):
     return unicodedata.normalize('NFKC',s)
 


### PR DESCRIPTION
I'm proposing this as NFC/NFD normalization is definitely useful
for some models, and this allows users to load models which use
one of these normalizations. PR#257 (the proposal to use NFC by
default didn't get enough traction to merge), but this at least allows
those of us who benefit from alternative normalization to distribute
our models to users, without having to ask them to apply a patch.

While NFKC is kept as the default, this gives the option to use NFC
and NFD normalization options. These can't be used directly, but
allow a model that has been trained with an alternative
normalization to be loaded and used. Without this patch, such a
model will throw an error when unpickling such a model.

Such a model can be built using different normalization= parameters,
as for example in PR#257.