### PR TITLE
Fix arguments for function sigmoid

### DIFF
--- a/OLD/mlinear.py
+++ b/OLD/mlinear.py
@@ -298,7 +298,7 @@ class LinKernelClassifier:
         if self.linear:
             pred = dot(make2d(data),self.M.T)
         else:
-            pred = sigmoid(make2d(data),self.M.T)
+            pred = sigmoid(dot(make2d(data),self.M.T))
         return [[(c,p[i]) for i,c in enumerate(self.classlist)] for j,p in enumerate(pred)]
     def classify(self,data):
         assert data.ndim>=2


### PR DESCRIPTION
Error reported by LGTM:

    Call to function sigmoid with too many arguments;
    should be no more than 1.

Fix it by using the same pattern as in previous calls of that function.

Signed-off-by: Stefan Weil <sw@weilnetz.de>